### PR TITLE
Remove get by ID

### DIFF
--- a/_config/auth0.yml
+++ b/_config/auth0.yml
@@ -13,7 +13,6 @@ SilverStripe\Control\Director:
     'auth//updateProfile': 'DirectLease\Auth0\ApiController'
     'auth//updateUserMetadata': 'DirectLease\Auth0\ApiController'
     'auth//sendVerificationMail': 'DirectLease\Auth0\ApiController'
-    'auth//getIdByEmail': 'DirectLease\Auth0\ApiController'
 ---
 Name: auth0
 After:

--- a/src/Controller/ApiController.php
+++ b/src/Controller/ApiController.php
@@ -191,9 +191,15 @@ class ApiController extends Controller
     }
 
     
-    protected function getIdByEmail()
+   /**
+    * A function that for given email returns the auth0id can be used when initing this controller and than call this function
+    * This function is not exposed externally 
+    * 
+    * @param string email email
+    * @return mixed
+    */
+    protected function getIdByEmail(string $email)
     {
-        $email = $this->request->postVar('email');
         $email_string = ':"' . urlencode($email) . '"';
         $query_string = 'email' .$email_string . '&search_engine=v3';
 
@@ -202,7 +208,7 @@ class ApiController extends Controller
         if (!empty($response)) {
             return $response[0]->user_id;
         } else {
-            return null;
+            return false;
         }
     }
 

--- a/src/Controller/ApiController.php
+++ b/src/Controller/ApiController.php
@@ -33,8 +33,7 @@ class ApiController extends Controller
         'updateProfile',
         'updateUserMetadata',
         'sendVerificationMail',
-        'checkAndCreateAuth0UserAccount',
-        'getIdByEmail'
+        'checkAndCreateAuth0UserAccount'
     );
 
 
@@ -191,7 +190,8 @@ class ApiController extends Controller
         $this->redirect($redirect_to);
     }
 
-    public function getIdByEmail()
+    
+    protected function getIdByEmail()
     {
         $email = $this->request->postVar('email');
         $email_string = ':"' . urlencode($email) . '"';


### PR DESCRIPTION
Remove get by ID, risk of users abusing the external ip to see if users exists.